### PR TITLE
Add option to create replicated objects with original id

### DIFF
--- a/bin/replicate
+++ b/bin/replicate
@@ -10,6 +10,7 @@
 #/   -r, --require        Require the library. Often used with 'config/environment'.
 #/   -d, --dump           Dump the repository and all related objects to stdout.
 #/   -l, --load           Load dump file data from stdin.
+#/   -i, --keep-id        Use replicated ids when loading dump file.
 #/
 #/   -v, --verbose        Write more status output.
 #/   -q, --quiet          Write less status output.
@@ -20,6 +21,7 @@ require 'optparse'
 mode     = nil
 verbose  = false
 quiet    = false
+keep_id  = false
 out      = $stdout
 
 # parse arguments
@@ -31,6 +33,7 @@ ARGV.options do |opts|
   opts.on("-r", "--require=f") { |file| require file }
   opts.on("-v", "--verbose")   { verbose = true }
   opts.on("-q", "--quiet")     { quiet = true }
+  opts.on("-i", "--keep-id")   { keep_id = true }
   opts.on_tail("-h", "--help", &usage)
   opts.parse!
 end
@@ -38,8 +41,9 @@ end
 # load rails environment and replicator lib.
 require 'replicate'
 
-# hack to enable AR query cache
 if defined?(ActiveRecord::Base)
+  ActiveRecord::Base.replicate_id = keep_id
+  # hack to enable AR query cache
   ActiveRecord::ConnectionAdapters::QueryCache.
     send :attr_writer, :query_cache, :query_cache_enabled
   ActiveRecord::Base.connection.send(:query_cache=, {})

--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -126,6 +126,18 @@ module Replicate
         @replicate_natural_key = attribute_names
       end
 
+      # Set or retrieve whether replicated object should keep its original id.
+      # When not set, replicated objects will be created with new id.
+      def replicate_id(boolean=nil)
+        self.replicate_id = boolean unless boolean.nil?
+        @replicate_id.nil? ? superclass.replicate_id : @replicate_id
+      end
+
+      # Set flag for replicating original id.
+      def replicate_id=(boolean)
+        @replicate_id = boolean
+      end
+
       # Load an individual record into the database. If the models defines a
       # replicate_natural_key then an existing record will be updated if found
       # instead of a new record being created.
@@ -158,9 +170,8 @@ module Replicate
       # running validations or callbacks.
       def create_or_update_replicant(instance, attributes)
         def instance.callback(*args);end # Rails 2.x hack to disable callbacks.
-
         attributes.each do |key, value|
-          next if key == primary_key
+          next if key == primary_key and not replicate_id
           instance.write_attribute key, value
         end
 
@@ -213,5 +224,6 @@ module Replicate
     ::ActiveRecord::Base.send :extend,  ClassMethods
     ::ActiveRecord::Base.replicate_associations = []
     ::ActiveRecord::Base.replicate_natural_key  = []
+    ::ActiveRecord::Base.replicate_id           = false
   end
 end


### PR DESCRIPTION
Hello.

I've noticed that by default `replicate` don't use original ids during recreation of objects. That's a good default, but sometimes there is a contrary need. For example, models with uploaders usually keep track of file by its id so usage of `replicate` can lead to broken asset paths in this case. Also there are rare cases when developer with poor taste hardcodes id references in codebase.

I've added a new option so we can deal with such situations. Developer simply should mark models:

```
class OfferImage
    replicate_id true
end
```

Also it can be done with command line option:
`replicate -r config/environment -li < user.dump`
