### PR TITLE
Natural key only find

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ end
 Multiple attribute names may be specified to define a compound key. Foreign key
 column attributes (`user_id`) are often included in natural keys.
 
+You can also use the :only_find option to disable creation or updating of unfound
+objects entirely:
+
+```ruby
+class EmailAddress < ActiveRecord::Base
+  belongs_to :user
+  replicate_natural_key :user_id, :email, :only_find => true
+end
+```
+
+In this example, loading a dump of users with email addresses will result in all
+users loaded, but they will have only the email addresses that are already in the
+target system.
+
 ### Validations and Callbacks
 
 __IMPORTANT:__ All ActiveRecord validations and callbacks are disabled on the

--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -125,10 +125,23 @@ module Replicate
       # Compound key used during load to locate existing objects for update.
       # When no natural key is defined, objects are created new.
       #
+      # Use :only_find => true as an option to only find existing objects - if
+      # none are found, they will not be created.
+      #
       # attribute_names - Macro style setter.
       def replicate_natural_key(*attribute_names)
+        options = attribute_names.last.is_a?(Hash) ? attribute_names.pop : {}
         self.replicate_natural_key = attribute_names if attribute_names.any?
+        self.only_find_natural_key = options[:only_find] if options.has_key?(:only_find)
         @replicate_natural_key || superclass.replicate_natural_key
+      end
+
+      def only_find_natural_key
+        @only_find_natural_key
+      end
+
+      def only_find_natural_key=(only_find)
+        @only_find_natural_key = only_find
       end
 
       # Set the compound key used to locate existing objects for update when
@@ -154,6 +167,8 @@ module Replicate
       # Load an individual record into the database. If the models defines a
       # replicate_natural_key then an existing record will be updated if found
       # instead of a new record being created.
+      # If the :only_find option is set to true on replicate_natural_key, will
+      # not create a new record if it isn't found.
       #
       # type  - Model class name as a String.
       # id    - Primary key id of the record on the dump system. This must be
@@ -162,8 +177,9 @@ module Replicate
       #
       # Returns the ActiveRecord object instance for the new record.
       def load_replicant(type, id, attributes)
-        instance = replicate_find_existing_record(attributes) || new
-        create_or_update_replicant instance, attributes
+        instance = replicate_find_existing_record(attributes)
+        return if instance.nil? and only_find_natural_key
+        create_or_update_replicant instance || new, attributes
       end
 
       # Locate an existing record using the replicate_natural_key attribute
@@ -286,6 +302,7 @@ module Replicate
     ::ActiveRecord::Base.send :extend,  ClassMethods
     ::ActiveRecord::Base.replicate_associations = []
     ::ActiveRecord::Base.replicate_natural_key  = []
+    ::ActiveRecord::Base.only_find_natural_key  = false
     ::ActiveRecord::Base.replicate_id           = false
   end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -270,6 +270,37 @@ class ActiveRecordTest < Test::Unit::TestCase
     end
   end
 
+  def test_only_find_natural_key
+    objects = []
+    @dumper.listen { |type, id, attrs, obj| objects << [type, id, attrs, obj] }
+
+    assert_equal(3, Profile.count)
+    assert_equal(3, User.count)
+
+    %w[rtomayko kneath tmm1].each do |login|
+      user = User.find_by_login(login)
+      @dumper.dump user
+    end
+    assert_equal 6, objects.size
+
+    User.find_by_login("kneath").profile.destroy
+    User.delete_all
+    assert_equal(0, User.count)
+    assert_equal(2, Profile.count)
+
+    # We only want to reattach profiles, not recreate them
+    Profile.replicate_natural_key :user_id, :only_find => true
+    
+     # load everything back up
+    objects.each { |type, id, attrs, obj| @loader.feed type, id, attrs }
+
+    assert_equal(3, User.count)
+    assert_equal(2, Profile.count)
+    assert_nil     User.find_by_login("kneath").profile
+    assert_not_nil User.find_by_login("rtomayko").profile
+    assert_not_nil User.find_by_login("tmm1").profile
+  end
+
   def test_loading_with_existing_records
     objects = []
     @dumper.listen { |type, id, attrs, obj| objects << [type, id, attrs, obj] }


### PR DESCRIPTION
Hoi, here's another feature I'm using.

FYI, when I use this in my project, I get warnings about missing key translations:

```
warn: ShippingCategory(655) not in keymap, referenced by Product(1069)#shipping_category_id
warn: Company(65) not in keymap, referenced by Product(1069)#company_id
```

But I can't reproduce this in the replicate tests. Since everything is still working, I'm still using this, but I don't know about you...
