### PR TITLE
Remove unwanted text in replication

### DIFF
--- a/bin/replicate
+++ b/bin/replicate
@@ -23,7 +23,7 @@
 #/   -v, --verbose        Write more status output.
 #/   -q, --quiet          Write less status output.
 $stderr.sync = true
-$stdout = File.new('/dev/null', 'w')
+$stdout = $stderr
 
 require 'optparse'
 


### PR DESCRIPTION
Sometimes gems add any messages to output on initialization phase.

For example, erubis gem add `** Erubis 2.7.0"` or newrelic add `Cannot find or read newrelic.yml`.

This noise breaks down dump loading.

I've fixed this situation. All previous output will be ignored in dump. And only result will be in output. 
