### PR TITLE
Automatically set replicate natural key as id if we're using replicate_id to keep original ids

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -154,6 +154,7 @@ module Replicate
 
       # Set flag for replicating original id.
       def replicate_id=(boolean)
+        self.replicate_natural_key = [:id] if boolean
         @replicate_id = boolean
       end
 
@@ -168,7 +169,7 @@ module Replicate
 
       # Set which, if any, attributes should not be dumped. Also works for
       # associations.
-      # 
+      #
       # attribute_names - Array of attribute name symbols
       def replicate_omit_attributes=(attribute_names)
         @replicate_omit_attributes = attribute_names


### PR DESCRIPTION
If we keeping original ids for some model then we should always set at least id as replicate natural key because otherwise we won't be able to replicate with duplicates.

I hope use case is clear, if not I can provide additional information :)
