### PR TITLE
Dump faster with more predictable RES mem growth

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -128,10 +128,10 @@ module Replicate
             dumper.dump(dependent)
 
             # clear reference to allow GC
-            if reflection.respond_to?(:reset)
-              reflection.reset
-            elsif respond_to?(meth = "set_#{reflection.name}_target")
-              send meth, nil
+            if respond_to?(:association)
+              association(reflection.name).reset
+            elsif respond_to?(:association_instance_set, true)
+              association_instance_set(reflection.name, nil)
             end
           else
             warn "warn: #{self.class}##{reflection.name} #{association_type} association " \


### PR DESCRIPTION
This speeds up the dump process and makes it less prone to huge memory growth.
- [x] Reset association targets after following and dumping. Previously, all associated objects were kept around until their parent object was entirely dumped. Now objects are only kept around until their association is fully dumped.
- [x] Avoid loading associated objects when their replicant key already exists in the dump map. Previously, we'd load associated objects just to determine their key. In `belongs_to` cases, it's possible to discern this info from the reflection class and foreign key.

This gave a 12x speed up or so when dumping about 250K objects. About half due to each of reduced GC time and avoiding AR object creation.
