### PR TITLE
handle cyclic associations

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -251,10 +251,11 @@ module Replicate
       # id    - Primary key id of the record on the dump system. This must be
       #         translated to the local system and stored in the keymap.
       # attrs - Hash of attributes to set on the new record.
+      # local_id - to reload an object with given local id
       #
       # Returns the ActiveRecord object instance for the new record.
-      def load_replicant(type, id, attributes)
-        instance = replicate_find_existing_record(attributes) || new
+      def load_replicant(type, id, attributes, local_id = nil)
+        instance = replicate_find_existing_record(attributes, local_id) || new
         create_or_update_replicant instance, attributes
       end
 
@@ -262,7 +263,8 @@ module Replicate
       # values.
       #
       # Returns the existing record if found, nil otherwise.
-      def replicate_find_existing_record(attributes)
+      def replicate_find_existing_record(attributes, id = nil)
+        return find_by_id(id) if not id.nil? and not find_by_id(id).nil?
         return if replicate_natural_key.empty?
         conditions = {}
         replicate_natural_key.each do |attribute_name|


### PR DESCRIPTION
cyclic associations lead to an infinite loop on dump, for instance

``` ruby
class Order < ActiveRecord::Base
  has_many    :states
  belongs_to  :last_state, :class_name => 'State'
end

class State < ActiveRecord::Base
  belongs_to  :order
end
```

I suggest two changes which I have implemented as a PoC:
1. on dump: prevent following loops in the object association graph by saving and checking for objects already seen in the traversal
2. on load: when a referenced object is missing, put the referrer on a wait list and reload it when the referee is loaded - otherwise there would be missing foreign keys
