### PR TITLE
Add an Option to Ignore Missing Types

### DIFF
--- a/lib/replicate/loader.rb
+++ b/lib/replicate/loader.rb
@@ -146,10 +146,16 @@ module Replicate
         string.split('::').inject ::Object do |namespace, name|
           if namespace.const_defined?(name)
             namespace.const_get(name)
-          elsif ignore_missing?
-            warn "ignoring missing type #{name}"
           else
-            namespace.const_missing(name)
+            begin
+              namespace.const_missing(name)
+            rescue NameError => e
+              if ignore_missing?
+                warn "ignoring missing type #{name}"
+              else
+                raise e
+              end
+            end
           end
         end
       end
@@ -159,10 +165,16 @@ module Replicate
         string.split('::').inject ::Object do |namespace, name|
           if namespace.const_defined?(name, false)
             namespace.const_get(name)
-          elsif ignore_missing?
-            warn "ignoring missing type #{name}"
           else
-            namespace.const_missing(name)
+            begin
+              namespace.const_missing(name)
+            rescue NameError => e
+              if ignore_missing?
+                warn "ignoring missing type #{name}"
+              else
+                raise e
+              end
+            end
           end
         end
       end

--- a/lib/replicate/loader.rb
+++ b/lib/replicate/loader.rb
@@ -143,8 +143,10 @@ module Replicate
         string.split('::').inject ::Object do |namespace, name|
           if namespace.const_defined?(name)
             namespace.const_get(name)
+          elsif ignore_missing?
+            warn "ignoring missing type #{name}"
           else
-            namespace.const_missing(name) unless ignore_missing?
+            namespace.const_missing(name)
           end
         end
       end
@@ -154,8 +156,10 @@ module Replicate
         string.split('::').inject ::Object do |namespace, name|
           if namespace.const_defined?(name, false)
             namespace.const_get(name)
+          elsif ignore_missing?
+            warn "ignoring missing type #{name}"
           else
-            namespace.const_missing(name) unless ignore_missing?
+            namespace.const_missing(name)
           end
         end
       end

--- a/lib/replicate/loader.rb
+++ b/lib/replicate/loader.rb
@@ -79,6 +79,9 @@ module Replicate
         new_id, instance = model_class.load_replicant(type, id, attributes)
       rescue => boom
         warn "error: loading #{type} #{id} #{boom.class} #{boom}"
+
+        return if ignore_missing?
+
         raise
       end
       register_id instance, type, id, new_id


### PR DESCRIPTION
This allows dumps taken on a newer version of the object graph (or database schema) to load in older versions where some object types (or active record models) are missing.
