### PR TITLE
belongs_to association fixes

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -51,6 +51,7 @@ module Replicate
 
         omitted_attributes.each { |omit| attributes.delete(omit.to_s) }
         self.class.reflect_on_all_associations(:belongs_to).each do |reflection|
+          next if omitted_attributes.include?(reflection.name)
           if info = replicate_reflection_info(reflection)
             if replicant_id = info[:replicant_id]
               foreign_key = info[:foreign_key].to_s

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -415,6 +415,17 @@ class ActiveRecordTest < Test::Unit::TestCase
     assert_equal 'Note', type
   end
 
+  def test_skips_belongs_to_information_if_omitted
+    objects = []
+    @dumper.listen { |type, id, attrs, obj| objects << [type, id, attrs, obj] }
+
+    Profile.replicate_omit_attributes :user
+    @dumper.dump @rtomayko.profile
+
+    assert_equal 1, objects.size
+    type, id, attrs, obj = objects.shift
+    assert_equal @rtomayko.profile.user_id, attrs["user_id"]
+  end
 
   def test_loading_everything
     objects = []


### PR DESCRIPTION
This fixes two bugs:
- For polymorphic belongs_to associations, the `replicate_reflection_info` method was using `Kernel.const_get` to look up the reference class. This failed on namespaced class names.
- For omitted belongs_to associations, the association information was still looked up rather than simply leaving the foreign key as-is. For example, an omitted `belongs_to :user` would write `[:id, "User", 1]` instead of just `1`.
