### PR TITLE
Add if block_given? to yield in AR callback statements

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -300,12 +300,12 @@ module Replicate
       def replicate_disable_callbacks(instance)
         if ::ActiveRecord::VERSION::MAJOR >= 3
           # AR 3.1.x
-          def instance.run_callbacks(*args); yield; end
+          def instance.run_callbacks(*args); yield if block_given?; end
 
           # AR 3.0.x
-          def instance._run_save_callbacks(*args); yield; end
-          def instance._run_create_callbacks(*args); yield; end
-          def instance._run_update_callbacks(*args); yield; end
+          def instance._run_save_callbacks(*args); yield if block_given?; end
+          def instance._run_create_callbacks(*args); yield if block_given?; end
+          def instance._run_update_callbacks(*args); yield if block_given?; end
         else
           # AR 2.x
           def instance.callback(*args)


### PR DESCRIPTION
This commit adds an if block_given? qualifier to the ActiveRecord
callbacks. If no block is given and these functions are called,
a JumpError is raised. This fixes that issue.
