### PR TITLE
disable after_commit callbacks

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -306,6 +306,7 @@ module Replicate
           def instance._run_save_callbacks(*args); yield; end
           def instance._run_create_callbacks(*args); yield; end
           def instance._run_update_callbacks(*args); yield; end
+          def instance._run_commit_callbacks(*args); yield; end
         else
           # AR 2.x
           def instance.callback(*args)

--- a/replicate.gemspec
+++ b/replicate.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.select {|path| path =~ /^test\/.*_test.rb/}
   s.add_development_dependency 'activerecord', '~> 3.1'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'test_after_commit'
 
   s.require_paths = %w[lib]
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -16,6 +16,7 @@ require 'replicate'
 dbfile = File.expand_path('../db', __FILE__)
 File.unlink dbfile if File.exist?(dbfile)
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => dbfile)
+require 'test_after_commit'
 
 # load schema
 ActiveRecord::Migration.verbose = false
@@ -561,6 +562,9 @@ class ActiveRecordTest < Test::Unit::TestCase
     # note when a record is saved with callbacks
     callbacks = false
     User.class_eval { after_save { callbacks = true } }
+    User.class_eval { after_create { callbacks = true } }
+    User.class_eval { after_update { callbacks = true } }
+    User.class_eval { after_commit { callbacks = true } }
 
     # check our assumptions
     user = User.create(:login => 'defunkt')


### PR DESCRIPTION
`after_commit` callbacks are getting run on AR 3.0. This pulls in the [test_after_commit](https://garage.github.com/grosser/test_after_commit) gem, which fires the after_commit callbacks even though there is still a transaction open.

/cc @rtomayko @rsanheim @rick
