### PR TITLE
Only yield from run_callbacks if there's a block to yield to

### DIFF
--- a/lib/replicate/active_record.rb
+++ b/lib/replicate/active_record.rb
@@ -299,8 +299,8 @@ module Replicate
       # they've been disabled on an object.
       def replicate_disable_callbacks(instance)
         if ::ActiveRecord::VERSION::MAJOR >= 3
-          # AR 3.1.x
-          def instance.run_callbacks(*args); yield; end
+          # AR 3.1.x, 3.2.x
+          def instance.run_callbacks(*args); yield if block_given?; end
 
           # AR 3.0.x
           def instance._run_save_callbacks(*args); yield; end


### PR DESCRIPTION
ActiveRecord 3.2 sometimes calls `run_callbacks` with no block. In this case we should just no-op and return, rather than yield anyway and raise a `LocalJumpError`.

cc @rtomayko
